### PR TITLE
Add support for continuous covariates

### DIFF
--- a/R/srcImpulseDE2_CostFunctionsFit.R
+++ b/R/srcImpulseDE2_CostFunctionsFit.R
@@ -45,25 +45,34 @@ evalLogLikMu <- function(
     if (scaMu < 10^(-10)) {
         scaMu <- 10^(-10)
     }
+
     
     vecBatchFactors <- array(1, length(vecCounts))
     if (!is.null(lsvecidxBatch)) {
-        for (vecidxConfounder in lsvecidxBatch) {
-            scaNBatchFactors <- max(vecidxConfounder) - 1  
-            # Batches are counted from 1
-            # Factor of first batch is one (constant), the remaining 
-            # factors scale based on the first batch.
-            vecBatchFacConf <- c(
-                1, exp(vecTheta[(scaNParamUsed + 1):
-                                    (scaNParamUsed + scaNBatchFactors)])
-            )[vecidxConfounder]
-            scaNParamUsed <- scaNParamUsed + scaNBatchFactors
-            # Prevent batch factor shrinkage and explosion:
-            vecBatchFacConf[vecBatchFacConf < 10^(-10)] <- 10^(-10)
-            vecBatchFacConf[vecBatchFacConf > 10^(10)] <- 10^(10)
+        #Now assuming that lsvecidxBatch is a dataframe containing only the covariates
+        matBatchFactors <- model.matrix(~ ., lsvecidxBatch)[,-1]
+
+        vecThetaCovar <- vecTheta[(scaNParamUsed + 1):(scaNParamUsed + ncol(matBatchFactors))]
+        vecBatchFactors <- t(exp(matBatchFactors %*% vecThetaCovar))
+        vecBatchFactors[vecBatchFactors < 10^(-10)] <- 10^(-10)
+        vecBatchFactors[vecBatchFactors > 10^(10)] <- 10^(10)
+
+        #for (vecidxConfounder in lsvecidxBatch) {
+            #scaNBatchFactors <- max(vecidxConfounder) - 1  
+            ## Batches are counted from 1
+            ## Factor of first batch is one (constant), the remaining 
+            ## factors scale based on the first batch.
+            #vecBatchFacConf <- c(
+                #1, exp(vecTheta[(scaNParamUsed + 1):
+                                    #(scaNParamUsed + scaNBatchFactors)])
+            #)[vecidxConfounder]
+            #scaNParamUsed <- scaNParamUsed + scaNBatchFactors
+            ## Prevent batch factor shrinkage and explosion:
+            #vecBatchFacConf[vecBatchFacConf < 10^(-10)] <- 10^(-10)
+            #vecBatchFacConf[vecBatchFacConf > 10^(10)] <- 10^(10)
             
-            vecBatchFactors <- vecBatchFactors * vecBatchFacConf
-        }
+            #vecBatchFactors <- vecBatchFactors * vecBatchFacConf
+        #}
     }
     
     # Compute log likelihood under constant model by adding log likelihood
@@ -171,22 +180,30 @@ evalLogLikImpulse <- function(
     
     vecBatchFactors <- array(1, length(vecCounts))
     if (!is.null(lsvecidxBatch)) {
-        for (vecidxConfounder in lsvecidxBatch) {
-            scaNBatchFactors <- max(vecidxConfounder) - 1  
-            # Batches are counted from 1
-            # Factor of first batch is one (constant), the remaining 
-            # factors scale based on the first batch.
-            vecBatchFacConf <- c(
-                1, exp(vecTheta[(scaNParamUsed +1):
-                                    (scaNParamUsed + scaNBatchFactors)])
-            )[vecidxConfounder]
-            scaNParamUsed <- scaNParamUsed + scaNBatchFactors
-            # Prevent batch factor shrinkage and explosion:
-            vecBatchFacConf[vecBatchFacConf < 10^(-10)] <- 10^(-10)
-            vecBatchFacConf[vecBatchFacConf > 10^(10)] <- 10^(10)
+        #Now assuming that lsvecidxBatch is a dataframe containing only the covariates
+        matBatchFactors <- model.matrix(~ ., lsvecidxBatch)[,-1]
+
+        vecThetaCovar <- vecTheta[(scaNParamUsed + 1):(scaNParamUsed + ncol(matBatchFactors))]
+        vecBatchFactors <- t(exp(matBatchFactors %*% vecThetaCovar))
+        vecBatchFactors[vecBatchFactors < 10^(-10)] <- 10^(-10)
+        vecBatchFactors[vecBatchFactors > 10^(10)] <- 10^(10)
+
+        #for (vecidxConfounder in lsvecidxBatch) {
+            #scaNBatchFactors <- max(vecidxConfounder) - 1  
+            ## Batches are counted from 1
+            ## Factor of first batch is one (constant), the remaining 
+            ## factors scale based on the first batch.
+            #vecBatchFacConf <- c(
+                #1, exp(vecTheta[(scaNParamUsed +1):
+                                    #(scaNParamUsed + scaNBatchFactors)])
+            #)[vecidxConfounder]
+            #scaNParamUsed <- scaNParamUsed + scaNBatchFactors
+            ## Prevent batch factor shrinkage and explosion:
+            #vecBatchFacConf[vecBatchFacConf < 10^(-10)] <- 10^(-10)
+            #vecBatchFacConf[vecBatchFacConf > 10^(10)] <- 10^(10)
             
-            vecBatchFactors <- vecBatchFactors * vecBatchFacConf
-        }
+            #vecBatchFactors <- vecBatchFactors * vecBatchFacConf
+        #}
     }
     
     # Compute log likelihood under impulse model by adding log likelihood of
@@ -290,22 +307,29 @@ evalLogLikSigmoid <- function(
     
     vecBatchFactors <- array(1, length(vecCounts))
     if (!is.null(lsvecidxBatch)) {
-        for (vecidxConfounder in lsvecidxBatch) {
-            scaNBatchFactors <- max(vecidxConfounder) - 1  
-            # Batches are counted from 1
-            # Factor of first batch is one (constant), the remaining 
-            # factors scale based on the first batch.
-            vecBatchFacConf <- c(
-                1, exp(vecTheta[(scaNParamUsed +1):
-                                    (scaNParamUsed + scaNBatchFactors)])
-            )[vecidxConfounder]
-            scaNParamUsed <- scaNParamUsed + scaNBatchFactors
-            # Prevent batch factor shrinkage and explosion:
-            vecBatchFacConf[vecBatchFacConf < 10^(-10)] <- 10^(-10)
-            vecBatchFacConf[vecBatchFacConf > 10^(10)] <- 10^(10)
+        matBatchFactors <- model.matrix(~ ., lsvecidxBatch)[,-1]
+
+        vecThetaCovar <- vecTheta[(scaNParamUsed + 1):(scaNParamUsed + ncol(matBatchFactors))]
+        vecBatchFactors <- t(exp(matBatchFactors %*% vecThetaCovar))
+        vecBatchFactors[vecBatchFactors < 10^(-10)] <- 10^(-10)
+        vecBatchFactors[vecBatchFactors > 10^(10)] <- 10^(10)
+
+        #for (vecidxConfounder in lsvecidxBatch) {
+            #scaNBatchFactors <- max(vecidxConfounder) - 1  
+            ## Batches are counted from 1
+            ## Factor of first batch is one (constant), the remaining 
+            ## factors scale based on the first batch.
+            #vecBatchFacConf <- c(
+                #1, exp(vecTheta[(scaNParamUsed +1):
+                                    #(scaNParamUsed + scaNBatchFactors)])
+            #)[vecidxConfounder]
+            #scaNParamUsed <- scaNParamUsed + scaNBatchFactors
+            ## Prevent batch factor shrinkage and explosion:
+            #vecBatchFacConf[vecBatchFacConf < 10^(-10)] <- 10^(-10)
+            #vecBatchFacConf[vecBatchFacConf > 10^(10)] <- 10^(10)
             
-            vecBatchFactors <- vecBatchFactors * vecBatchFacConf
-        }
+            #vecBatchFactors <- vecBatchFactors * vecBatchFacConf
+        #}
     }
     
     # Compute log likelihood under impulse model by adding log likelihood of

--- a/R/srcImpulseDE2_classImpulseDE2Object.R
+++ b/R/srcImpulseDE2_classImpulseDE2Object.R
@@ -186,9 +186,15 @@ setClassUnion("data.frameORNULL", members = c("data.frame", "NULL"))
 #' @slot boolCaseCtrl (bool) 
 #' Whether to perform case-control analysis. Does case-only
 #' analysis if FALSE.
+#' @slot boolBeta2 (bool)
+#' Whether to model two different slopes for impulse model instead of 
+#' assuming onset slope and offset slope are identical.
 #' @slot vecConfounders (vector of strings number of confounding variables)
 #' Factors to correct for during batch correction. Have to 
 #' supply dispersion factors if more than one is supplied.
+#' Names refer to columns in dfAnnotation.
+#' @slot vecCovariates (vector of stings number of covaraites)
+#' Covariates to adjust for during differential analysis.
 #' Names refer to columns in dfAnnotation.
 #' @slot scaNProc (scalar) Number of processes for 
 #' parallelisation.
@@ -204,7 +210,10 @@ setClass("ImpulseDE2Object", slots = c(
     dfImpulseDE2Results = "data.frameORNULL", 
     vecDEGenes = "characterORNULL", lsModelFits = "listORNULL", matCountDataProc = "matrix", 
     vecAllIDs = "characterORNULL", dfAnnotationProc = "data.frame", vecSizeFactors = "numeric", 
-    vecDispersions = "numeric", boolCaseCtrl = "logical", vecConfounders = "characterORNULL", 
+    vecDispersions = "numeric", boolCaseCtrl = "logical", 
+    boolBeta2 = "logical",
+    vecConfounders = "characterORNULL", 
+    vecCovariates = "characterORNULL", 
     scaNProc = "numeric", scaQThres = "numericORNULL", strReport = "characterORNULL"))
 
 ### 2. Enable accession of private elements via functions
@@ -225,7 +234,9 @@ setClass("ImpulseDE2Object", slots = c(
 #' get_vecSizeFactors
 #' get_vecDispersions 
 #' get_boolCaseCtrl
+#' get_boolBeta2
 #' get_vecConfounders 
+#' get_vecCovariates
 #' get_scaNProc
 #' get_scaQThres
 #' get_strReport
@@ -244,7 +255,9 @@ setClass("ImpulseDE2Object", slots = c(
 #' matCountData    = lsSimulatedData$matObservedCounts, 
 #' dfAnnotation    = lsSimulatedData$dfAnnotation,
 #' boolCaseCtrl    = FALSE,
+#' boolBeta2       = FALSE,
 #' vecConfounders  = NULL,
+#' vecCovariates   = NULL,
 #' scaNProc        = 1 )
 #' # Extract hidden auxillary result and processed input objects.
 #' lsModelFits <- get_lsModelFits(objectImpulseDE2)
@@ -254,7 +267,9 @@ setClass("ImpulseDE2Object", slots = c(
 #' vecSizeFactors <- get_vecSizeFactors(objectImpulseDE2)
 #' vecDispersions <- get_vecDispersions(objectImpulseDE2)
 #' boolCaseCtrl <- get_boolCaseCtrl(objectImpulseDE2)
+#' boolBeta2 <- get_boolBeta2(objectImpulseDE2)
 #' vecConfounders <- get_vecConfounders(objectImpulseDE2)
+#' vecCovariates <- get_vecConfounders(objectImpulseDE2)
 #' scaNProc <- get_scaNProc(objectImpulseDE2)
 #' scaQThres <- get_scaQThres(objectImpulseDE2)
 #' strReport <- get_strReport(objectImpulseDE2)
@@ -299,8 +314,18 @@ get_boolCaseCtrl <- function(obj)
 
 #' @rdname get_accessors
 #' @export
+get_boolBeta2 <- function(obj) 
+    return(obj@boolBeta2)
+
+#' @rdname get_accessors
+#' @export
 get_vecConfounders <- function(obj) 
     return(obj@vecConfounders)
+
+#' @rdname get_accessors
+#' @export
+get_vecCovariates <- function(obj) 
+    return(obj@vecCovariates)
 
 #' @rdname get_accessors
 #' @export
@@ -330,12 +355,14 @@ get_strReport <- function(obj)
 #' 
 #' @aliases 
 #' set_boolCaseCtrl
+#' set_boolBeta2
 #' set_dfAnnotationProc
 #' set_dfImpulseDE2Results
 #' set_lsModelFits
 #' set_matCountDataProc
 #' set_vecAllIDs
 #' set_vecConfounders
+#' set_vecCovariates
 #' set_vecDEGenes
 #' set_vecDispersions
 #' set_vecSizeFactors 
@@ -352,6 +379,12 @@ NULL
 #' @name set_accessors
 set_boolCaseCtrl <- function(obj,element) {
     obj@boolCaseCtrl <- element
+    return(obj)
+}
+
+#' @name set_accessors
+set_boolBeta2 <- function(obj,element) {
+    obj@boolBeta2 <- element
     return(obj)
 }
 
@@ -410,6 +443,12 @@ set_vecConfounders <- function(obj,element) {
 }
 
 #' @name set_accessors
+set_vecCovariates <- function(obj,element) {
+    obj@vecCovariates <- element
+    return(obj)
+}
+
+#' @name set_accessors
 set_vecDEGenes <- function(obj,element) {
     obj@vecDEGenes <- element
     return(obj)
@@ -456,7 +495,9 @@ set_vecSizeFactors <- function(obj,element) {
 #' matCountData    = lsSimulatedData$matObservedCounts, 
 #' dfAnnotation    = lsSimulatedData$dfAnnotation,
 #' boolCaseCtrl    = FALSE,
+#' boolBeta2       = FALSE,
 #' vecConfounders  = NULL,
+#' vecCovariates   = NULL,
 #' scaNProc        = 1 )
 #' names(objectImpulseDE2) # Display core output
 #' # With respect to this core output, objectImpulseDE2
@@ -543,7 +584,9 @@ append_strReport <- function(obj,s) {
 #' matCountData    = lsSimulatedData$matObservedCounts, 
 #' dfAnnotation    = lsSimulatedData$dfAnnotation,
 #' boolCaseCtrl    = FALSE,
+#' boolBeta2       = FALSE,
 #' vecConfounders  = NULL,
+#' vecCovariates   = NULL,
 #' scaNProc        = 1 )
 #' # Uncomment to run:
 #' #writeReportToFile(

--- a/R/srcImpulseDE2_evalImpulse.R
+++ b/R/srcImpulseDE2_evalImpulse.R
@@ -9,7 +9,7 @@
 #' @seealso Compiled version: \link{evalImpulse_comp}
 #' 
 #' @param vecImpulseParam (numeric vector number of impulse model parameters)
-#' \{beta, h0, h1, h2, t1, t2\}
+#' \{beta, h0, h1, h2, t1, t2\} or \{beta1, beta2, h0, h1, h2, t1, t2\}
 #' Vector of impulse model parameters.
 #' @param vecTimepoints (numeric vector length number of time points) 
 #' Time points to be evaluated.
@@ -20,17 +20,37 @@
 #' @author David Sebastian Fischer
 evalImpulse <- function(vecImpulseParam, vecTimepoints) {
     
-    # beta is vecImpulseParam[1] h0 is vecImpulseParam[2] h1 is
-    # vecImpulseParam[3] h2 is vecImpulseParam[4] t1 is vecImpulseParam[5]
-    # t2 is vecImpulseParam[6]
-    
-    vecImpulseValue <- sapply(vecTimepoints, function(t) {
-        (1/vecImpulseParam[3]) * 
-            (vecImpulseParam[2] + (vecImpulseParam[3] - vecImpulseParam[2]) *
-                 (1/(1 + exp(-vecImpulseParam[1] * (t - vecImpulseParam[5]))))) *
-            (vecImpulseParam[4] + (vecImpulseParam[3] - vecImpulseParam[4]) *
-                 (1/(1 + exp(vecImpulseParam[1] * (t - vecImpulseParam[6])))))
-    })
+    if(length(vecImpulseParam) == 6){
+        # beta is vecImpulseParam[1] 
+        # h0 is vecImpulseParam[2] 
+        # h1 is vecImpulseParam[3] 
+        # h2 is vecImpulseParam[4] 
+        # t1 is vecImpulseParam[5]
+        # t2 is vecImpulseParam[6]
+        vecImpulseValue <- sapply(vecTimepoints, function(t) {
+            (1/vecImpulseParam[3]) * 
+                (vecImpulseParam[2] + (vecImpulseParam[3] - vecImpulseParam[2]) *
+                     (1/(1 + exp(-vecImpulseParam[1] * (t - vecImpulseParam[5]))))) *
+                (vecImpulseParam[4] + (vecImpulseParam[3] - vecImpulseParam[4]) *
+                     (1/(1 + exp(vecImpulseParam[1] * (t - vecImpulseParam[6])))))
+        })
+    }else if(length(vecImpulseParam) == 7){
+        # beta1 is vecImpulseParam[1] 
+        # beta2 is vecImpulseParam[2] 
+        # h0 is vecImpulseParam[3] 
+        # h1 is vecImpulseParam[4] 
+        # h2 is vecImpulseParam[5] 
+        # t1 is vecImpulseParam[6]
+        # t2 is vecImpulseParam[7]
+        vecImpulseValue <- sapply(vecTimepoints, function(t) {
+            (1/vecImpulseParam[4]) * 
+                (vecImpulseParam[3] + (vecImpulseParam[4] - vecImpulseParam[3]) *
+                     (1/(1 + exp(-vecImpulseParam[1] * (t - vecImpulseParam[6]))))) *
+                (vecImpulseParam[5] + (vecImpulseParam[4] - vecImpulseParam[5]) *
+                     (1/(1 + exp(-vecImpulseParam[2] * (t - vecImpulseParam[7])))))
+        })
+    }
+
     vecImpulseValue[vecImpulseValue < 10^(-10)] <- 10^(-10)
     
     return(vecImpulseValue)
@@ -42,7 +62,7 @@ evalImpulse <- function(vecImpulseParam, vecTimepoints) {
 #' Refer to \link{evalImpulse}.
 #' 
 #' @param vecImpulseParam (numeric vector number of impulse model parameters)
-#' \{beta, h0, h1, h2, t1, t2\}
+#' \{beta, h0, h1, h2, t1, t2\} or \{beta1, beta2, h0, h1, h2, t1, t2\}
 #' Vector of impulse model parameters.
 #' @param vecTimepoints (numeric vector length number of time points) 
 #' Time points to be evaluated.

--- a/R/srcImpulseDE2_fitSigmoid.R
+++ b/R/srcImpulseDE2_fitSigmoid.R
@@ -135,7 +135,7 @@ estimateSigmoidParam <- function(
 #' @param vecidxTimepoint (index vector length number of samples)
 #' Index of of time point assigned to each sample in vector
 #' vecTimepointsUnique.
-#' @param MAXIT (scalar) [Default 1000] 
+#' @param MAXIT (scalar)
 #' Maximum number of BFGS iterations for model fitting with \link{optim}.
 #' @param RELTOL (scalar) [Default 10^(-8)]
 #' Maximum relative change in loglikelihood to reach convergence in
@@ -168,7 +168,7 @@ estimateSigmoidParam <- function(
 fitSigmoidModel <- function(
     vecSigmoidParamGuess, vecCounts, scaDisp, vecSizeFactors, 
     lsvecidxBatch, vecTimepointsUnique, vecidxTimepoint, 
-    MAXIT = 1000, RELTOL = 10^(-8), trace = 0, REPORT = 10) {
+    MAXIT, RELTOL = 10^(-8), trace = 0, REPORT = 10) {
     
     
     vecParamGuess <- vecSigmoidParamGuess
@@ -286,7 +286,7 @@ fitSigmoidModel <- function(
 #' Each vector has one entry per sample with the index of the batch ID
 #' within the given confounding variable of the given sample. Reference
 #' is the list of unique batch ids for each confounding variable.
-#' @param MAXIT (scalar) [Default 1000] 
+#' @param MAXIT (scalar)
 #' Maximum number of BFGS iterations for model fitting with \link{optim}.
 #' 
 #' @return (list) 
@@ -312,7 +312,7 @@ fitSigmoidModel <- function(
 #' @author David Sebastian Fischer
 fitSigmoidGene <- function(
     vecCounts, scaDisp, vecSizeFactors, vecTimepointsUnique, 
-    vecidxTimepoint, lsvecidxBatch, MAXIT = 1000) {
+    vecidxTimepoint, lsvecidxBatch, MAXIT) {
     
     # (I) Fit sigmoidal model 1. Compute initialisations
     lsParamGuesses <- estimateSigmoidParam(
@@ -366,6 +366,8 @@ fitSigmoidGene <- function(
 #' @param strCondition (str)
 #' Name of condition entry in lsModelFits for which sigmoidal
 #' models are to be fit to each gene.
+#' @param MAXIT (scalar)
+#' Maximum number of BFGS iterations for model fitting with \link{optim}.
 #' 
 #' @return objectImpulseDE2 (object class ImpulseDE2Object)
 #' Object with sigmoidal fit added: objectImpulseDE2@@lsModelFits
@@ -476,7 +478,7 @@ fitSigmoidGene <- function(
 #' @author David Sebastian Fischer
 #' 
 #' @export
-fitSigmoidModels <- function(objectImpulseDE2, vecConfounders, strCondition) {
+fitSigmoidModels <- function(objectImpulseDE2, vecConfounders, strCondition, MAXIT) {
     
     dfAnnot <- get_dfAnnotationProc(obj=objectImpulseDE2)
     lsModelFits <- get_lsModelFits(obj=objectImpulseDE2)
@@ -498,7 +500,7 @@ fitSigmoidModels <- function(objectImpulseDE2, vecConfounders, strCondition) {
     
     # Maximum number of iterations for numerical optimisation of likelihood
     # function in MLE fitting of sigmoidal model:
-    MAXIT <- 1000
+    #MAXIT <- 1000
     
     vecGeneIDs <- rownames(get_matCountDataProc(obj=objectImpulseDE2))
     lsSigmoidFits <- bplapply(vecGeneIDs, function(x) {
@@ -511,7 +513,8 @@ fitSigmoidModels <- function(objectImpulseDE2, vecConfounders, strCondition) {
                     obj=objectImpulseDE2)[vecSamplesCond], 
                 vecTimepointsUnique = vecTimepointsUniqueCond, 
                 vecidxTimepoint = vecidxTimepointCond, 
-                lsvecidxBatch = lsvecidxBatchCond, MAXIT = MAXIT)
+                lsvecidxBatch = lsvecidxBatchCond, 
+                MAXIT = MAXIT)
         })
     names(lsSigmoidFits) <- vecGeneIDs
     

--- a/R/srcImpulseDE2_fitSigmoid.R
+++ b/R/srcImpulseDE2_fitSigmoid.R
@@ -49,18 +49,26 @@ estimateSigmoidParam <- function(
     if (!is.null(lsvecidxBatch)) {
         # Estimate batch factors
         vecBatchFactors <- array(1, length(vecCounts))
-        for (vecidxBatch in lsvecidxBatch) {
-            vecBatchFactorsConfounder <- tapply(
-                vecCountsSFcorrectedNorm, 
-                vecidxBatch, 
-                mean, na.rm=TRUE)
-            # Catch exception that all observations of a batch are zero or all
-            # observations are zero:
-            vecBatchFactorsConfounder[is.na(vecBatchFactorsConfounder) | 
-                                          vecBatchFactorsConfounder == 0] <- 1
-            vecBatchFactors <- vecBatchFactors * 
-                vecBatchFactorsConfounder[vecidxBatch]
-        }
+
+        lmBatchFactors <- lm(vecCountsSFcorrectedNorm ~ ., lsvecidxBatch)
+        matBatchFactors <- model.matrix(~ ., lsvecidxBatch)
+        coefBatchFactors <- coef(lmBatchFactors)
+        vecBatchFactors <- t(matBatchFactors %*% coefBatchFactors)
+        vecBatchFactors[is.na(vecBatchFactors) | vecBatchFactors == 0] <- 1
+
+        #for (vecidxBatch in lsvecidxBatch) {
+            #vecBatchFactorsConfounder <- tapply(
+                #vecCountsSFcorrectedNorm, 
+                #vecidxBatch, 
+                #mean, na.rm=TRUE)
+            ## Catch exception that all observations of a batch are zero or all
+            ## observations are zero:
+            #vecBatchFactorsConfounder[is.na(vecBatchFactorsConfounder) | 
+                                          #vecBatchFactorsConfounder == 0] <- 1
+            #vecBatchFactors <- vecBatchFactors * 
+                #vecBatchFactorsConfounder[vecidxBatch]
+        #}
+
         vecCountsSFBatchcorrected <- vecCountsSFcorrected/vecBatchFactors
         vecExpressionMeans <- tapply(
             vecCountsSFBatchcorrected, 

--- a/R/srcImpulseDE2_plotGenes.R
+++ b/R/srcImpulseDE2_plotGenes.R
@@ -129,6 +129,8 @@ plotGenes <- function(
             min(get_dfAnnotationProc(obj=objectImpulseDE2)$Time), 
                                 max(get_dfAnnotationProc(obj=objectImpulseDE2)$Time), 
                                 length.out = 100)
+
+        # Values from fitted impulse model 
         vecCaseImpulseParam <- get_lsModelFits(
             obj=objectImpulseDE2)$case[[id]]$lsImpulseFit$vecImpulseParam
         vecCaseImpulseValue <- evalImpulse_comp(
@@ -300,7 +302,8 @@ plotGenes <- function(
             }
         }
         gplotID <- gplotGene + scale_colour_manual(values = cbPalette) + 
-            xlab("time [hours]") + ylab("Read counts")
+            xlab("Time [hours]") + ylab("Size-factor-adjusted counts") +
+            theme_classic()
         if (!is.null(strNameRefMethod)) {
             gplotID <- gplotID + 
                 labs(title = paste0(

--- a/R/srcImpulseDE2_runDEAnalysis.R
+++ b/R/srcImpulseDE2_runDEAnalysis.R
@@ -85,7 +85,7 @@
 #' @author David Sebastian Fischer
 runDEAnalysis <- function(
     objectImpulseDE2, boolCaseCtrl, 
-    boolIdentifyTransients, scaQThresTransients = 0.001) {
+    boolIdentifyTransients, boolBeta2, scaQThresTransients = 0.001) {
     
     dfAnnot <- get_dfAnnotationProc(obj = objectImpulseDE2)
     
@@ -111,7 +111,11 @@ runDEAnalysis <- function(
         }
         # 6 impulse model parameters, 1 dispersion estimate and 1 batch factor
         # for each batch (except for the first one) for each confounder.
-        scaDegFreedomFull <- 6 + 1 + scaNBatchFactors
+        if(boolBeta2){
+            scaDegFreedomFull <- 7 + 1 + scaNBatchFactors
+        }else{
+            scaDegFreedomFull <- 6 + 1 + scaNBatchFactors
+        }
         # 1 constant model parameter1, 1 dispersion estimate and 1 batch factor
         # for each batch (except for the first one) for each confounder.
         scaDegFreedomRed <- 1 + 1 + scaNBatchFactors
@@ -155,10 +159,18 @@ runDEAnalysis <- function(
         # 6 impulse model parameters for each case and control, 1 dispersion
         # estimate and 1 batch factor for each batch (except for the first one)
         # for each confounder in each condition.
-        scaDegFreedomFull <- 6 * 2 + 1 + scaNBatchFactorsFull
-        # 6 impulse model parameters, 1 dispersion estimate and 1 batch factor
-        # for each batch (except for the first one) for each confounder.
-        scaDegFreedomRed <- 6 + 1 + scaNBatchFactorsRed
+        if(boolBeta2){
+            scaDegFreedomFull <- 7 * 2 + 1 + scaNBatchFactorsFull
+            # 6 impulse model parameters, 1 dispersion estimate and 1 batch factor
+            # for each batch (except for the first one) for each confounder.
+            scaDegFreedomRed <- 7 + 1 + scaNBatchFactorsRed 
+        }else{
+            scaDegFreedomFull <- 6 * 2 + 1 + scaNBatchFactorsFull
+            # 6 impulse model parameters, 1 dispersion estimate and 1 batch factor
+            # for each batch (except for the first one) for each confounder.
+            scaDegFreedomRed <- 6 + 1 + scaNBatchFactorsRed       
+        }
+
         vecConvergenceImpulseCombined <- sapply(
             get_lsModelFits(obj=objectImpulseDE2)$combined, 
             function(fit) fit$lsImpulseFit$scaConvergence)
@@ -236,7 +248,11 @@ runDEAnalysis <- function(
                 scaNBatchFactors <- 0
             }
         }
-        scaDegFreedomImpulse <- 6 + 1 + scaNBatchFactors
+        if(boolBeta2){
+            scaDegFreedomImpulse <- 7 + 1 + scaNBatchFactors
+        }else{
+            scaDegFreedomImpulse <- 6 + 1 + scaNBatchFactors
+        }
         scaDegFreedomSigmoid <- 4 + 1 + scaNBatchFactors
         scaDegFreedomConst <- 1 + 1 + scaNBatchFactors
         
@@ -278,7 +294,7 @@ runDEAnalysis <- function(
             as.numeric(vecPvalueSigmoidConst)
         dfDEAnalysis$sigmoidTOconst_padj <- 
             as.numeric(vecPvalueSigmoidConstBH)
-        # Classify trajectories as tranient change or monotonous change
+        # Classify trajectories as transient change or monotonous change
         # (transition).  Note that significant impulse vs sigmoid hits include
         # monotonous fits which are better fit by impulse than by sigmoid, this
         # is corrected for here.
@@ -441,7 +457,9 @@ updateDEAnalysis <- function(objectImpulseDE2, scaQThresTransients = 0.001) {
     objectImpulseDE2 <- runDEAnalysis(
         objectImpulseDE2 = objectImpulseDE2, 
         boolCaseCtrl = get_boolCaseCtrl(obj=objectImpulseDE2), 
-        boolIdentifyTransients = TRUE, scaQThresTransients = scaQThresTransients)
+        boolIdentifyTransients = TRUE, 
+        boolBeta2 = get_boolBeta2(obj=objectImpulseDE2), 
+        scaQThresTransients = scaQThresTransients)
     
     return(objectImpulseDE2)
 }

--- a/R/srcImpulseDE2_simulateDataSet.R
+++ b/R/srcImpulseDE2_simulateDataSet.R
@@ -10,7 +10,7 @@
 #' are returned). The remaining objects representing hidden
 #' parameters can be used to evaluate parameter estimates.
 #' 
-#' @seealso Called by separately by user.
+#' @seealso Called separately by user.
 #' 
 #' @param vecTimePointsA (numeric vector number of time points)
 #' Number of time points in batch A.

--- a/qc_branch.Rmd
+++ b/qc_branch.Rmd
@@ -1,0 +1,155 @@
+---
+title: "QC ImpulseDE2"
+author: "Nicole Gay"
+date: "6/2/2020"
+output: html_document
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+knitr::opts_knit$set(root.dir = '/oak/stanford/groups/smontgom/nicolerg/src/MOTRPAC/ImpulseDE2/R/')
+library(compiler)
+library(Biobase)
+library(BiocParallel)
+library(circlize)
+library(ComplexHeatmap)
+library(cowplot)
+library(DESeq2)
+library(ggplot2)
+library(grDevices)
+library(knitr)
+library(Matrix)
+library(methods)
+library(stats)
+library(SummarizedExperiment)
+library(utils)
+```
+
+## Source my edited version of ImpulseDE2
+```{r source functions}
+for(f in list.files()){
+  print(f)
+  source(f)
+}
+```
+
+## Starting point - simulated data 
+```{r simulate data}
+# case-only with batch effects
+lsSimulatedData <- simulateDataSetImpulseDE2(
+  vecTimePointsA   = rep(seq(1,8),3),
+  vecTimePointsB   = NULL,
+  vecBatchesA      = c(rep("B1",8), rep("B2",8), rep("B3",8)),
+  vecBatchesB      = NULL,
+  scaNConst        = 30,
+  scaNImp          = 50,
+  scaNLin          = 10,
+  scaNSig          = 30,
+  scaMuBatchEffect = 1,
+  scaSDBatchEffect = 0.2,
+  dirOutSimulation = NULL)
+```
+
+## Scenario 1: only covariates (no batch effects); two betas
+```{r adjust df}
+dfAnnotation = lsSimulatedData$dfAnnotation
+matCounts = lsSimulatedData$matObservedCounts
+dim(matCounts)
+dfAnnotation
+# call "Batch" something else
+colnames(dfAnnotation)[colnames(dfAnnotation) == 'Batch'] = 'sample_batch'
+# add sex covariate
+dfAnnotation$sex = sample(c('male','female'), replace=TRUE, size=nrow(dfAnnotation))
+# add continuous covariate
+dfAnnotation$num_var = rnorm(nrow(dfAnnotation))
+head(dfAnnotation)
+table(dfAnnotation$Time, dfAnnotation$sample_batch)
+```
+
+```{r set params}
+matCountData = matCounts
+boolCaseCtrl = FALSE
+vecConfounders = NULL # I feel like this should be reserved for true confounders, not covariates
+vecCovariates = c('sex','num_var','sample_batch')
+scaNProc = 1
+boolVerbose = TRUE
+boolBeta2 = TRUE
+scaQThres = NULL
+```
+
+```{r processData}
+objectImpulseDE2 = runImpulseDE2(
+    matCountData = matCountData, 
+    dfAnnotation = dfAnnotation, 
+    boolCaseCtrl = FALSE,
+    boolBeta2 = TRUE,
+    boolIdentifyTransients = TRUE,
+    vecConfounders = vecConfounders,
+    vecCovariates = NULL,
+    scaNProc = 1,
+    MAXIT = 5000) 
+modelFits = get_lsModelFits(obj=objectImpulseDE2)
+modelFits$case$gene71$lsImpulseFit$vecImpulseParam
+
+singleBeta = runImpulseDE2(
+    matCountData = matCountData, 
+    dfAnnotation = dfAnnotation, 
+    boolCaseCtrl = FALSE,
+    boolBeta2 = FALSE,
+    boolIdentifyTransients = TRUE,
+    vecConfounders = vecConfounders,
+    vecCovariates = NULL,
+    scaNProc = 1,
+    MAXIT = 5000) 
+modelFits = get_lsModelFits(obj=singleBeta)
+modelFits$case$gene71$lsImpulseFit$vecImpulseParam
+
+lsgplotsGenes <- plotGenes(
+  vecGeneIDs       = objectImpulseDE2$dfImpulseDE2Results[dfres$isTransient == TRUE, "Gene"],
+  #scaNTopIDs       = 10,
+  objectImpulseDE2 = objectImpulseDE2,
+  boolCaseCtrl     = FALSE,
+  dirOut           = NULL,
+  strFileName      = NULL,
+  vecRefPval       = NULL, 
+  strNameRefMethod = NULL)
+print(lsgplotsGenes[[1]])
+
+lsgplotsGenes <- plotGenes(
+  vecGeneIDs       = "gene71",
+  #scaNTopIDs       = 10,
+  objectImpulseDE2 = singleBeta,
+  boolCaseCtrl     = FALSE,
+  dirOut           = NULL,
+  strFileName      = NULL,
+  vecRefPval       = NULL, 
+  strNameRefMethod = NULL)
+print(lsgplotsGenes[[1]])
+```
+
+```{r look at output}
+dfres = objectImpulseDE2$dfImpulseDE2Results
+head(dfres)
+
+objectImpulseDE2$dfImpulseDE2Results
+
+objectImpulseDE2$dfImpulseDE2Results["gene40",]
+objectImpulseDE2$dfImpulseDE2Results[objectImpulseDE2$dfImpulseDE2Results$isTransient==TRUE,]
+modelFits = get_lsModelFits(obj=objectImpulseDE2)
+names(modelFits)
+names(modelFits$case)
+modelFits$case$gene40
+
+lsgplotsGenes <- plotGenes(objectImpulseDE2, 
+  #vecGeneIDs       = dfres[dfres$isTransient == TRUE, "Gene"],
+  scaNTopIDs       = 10,
+  objectImpulseDE2 = objectImpulseDE2,
+  boolCaseCtrl     = FALSE,
+  dirOut           = NULL,
+  strFileName      = NULL,
+  vecRefPval       = NULL, 
+  strNameRefMethod = NULL)
+print(lsgplotsGenes[[5]])
+
+c(1, exp(c(0,0):(9)))
+```


### PR DESCRIPTION
These changes should allow for the proper support of continuous covariates in both the likelihood functions (`evalLogLikMu`, `evalLogLikSigmoid`, and `evalLogLikImpulse`) and the covariate adjustment that happens before the estimation of the impulse (`estimateSigmoidParam`) and sigmoid (`estimateImpulseParam`) parameters.  

During covariate adjustment, the effects of all covariates are now being estimated simultaneously instead of independently as was done before.  This means that `vecCountsSFBatchcorrected` in `estimateSigmoidParam` and `estimateImpulseParam` will have a different value from the previous implementation if there are multiple batches which are not orthogonal to each other.  

Additionally, the use of a linear model to estimate the effects of continuous covariates in `estimateSigmoidParam` and `estimateImpulseParam` requires the covariates to be scaled and centered (to mean 0 and standard deviation 1) so that the covariate adjustment is independent of the scaling of the covariates.  

Lastly, the calls to `model.matrix` and `lm` assume that the covariates are in a data frame in which categorical covariates are factored.  Both this and the scaling of continuous covariates will be checked by other functions.